### PR TITLE
Drop `NPM_TOKEN` in favor of `OIDC` trusted publishing

### DIFF
--- a/.github/workflows/continuous-release.yaml
+++ b/.github/workflows/continuous-release.yaml
@@ -28,4 +28,3 @@ jobs:
           title: New release candidate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Switches the release workflow from a long-lived `NPM_TOKEN` secret to npm's OIDC-based trusted publishing.

## Changes

- Removes `NPM_TOKEN` env from the `changesets/action@v1` step
- `id-token: write` permission is already granted

## Required setup before merge

Trusted publisher must be registered on npmjs.com for **both** packages (Settings → Trusted Publisher → GitHub Actions):

- [x] `@simple-nominatim/core`
- [x] `@simple-nominatim/cli`

| Field | Value |
|---|---|
| Organization or user | `jonathanlinat` |
| Repository | `simple-nominatim` |
| Workflow filename | `continuous-release.yaml` |
| Environment name | *(blank)* |

## After merge

- Delete the `NPM_TOKEN` repo secret
- Re-run the release workflow on `main` to publish via OIDC