### PR TITLE
Improve `README` option metadata readability

### DIFF
--- a/.changeset/readme-lists.md
+++ b/.changeset/readme-lists.md
@@ -1,0 +1,6 @@
+---
+"@simple-nominatim/core": patch
+"@simple-nominatim/cli": patch
+---
+
+docs: convert inline option metadata to bullet lists in package READMEs for better readability

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,8 +40,15 @@ Every subcommand also accepts `--help` to list its full option set.
 simple-nominatim reverse:geocode --latitude '37.4219999' --longitude '-122.0840575' --format 'jsonv2'
 ```
 
-**Required:** `--latitude`, `--longitude`, `--format`.
-**Optional:** `--email`, `--zoom` (0–18), `--addressdetails`, `--layer`.
+- **Required:**
+  - `--latitude`
+  - `--longitude`
+  - `--format`
+- **Optional:**
+  - `--email`
+  - `--zoom` (0–18)
+  - `--addressdetails`
+  - `--layer`
 
 ### `search:free-form`
 
@@ -49,8 +56,18 @@ simple-nominatim reverse:geocode --latitude '37.4219999' --longitude '-122.08405
 simple-nominatim search:free-form --query 'Mountain View, CA, USA' --format 'jsonv2'
 ```
 
-**Required:** `--query`, `--format`.
-**Optional:** `--email`, `--limit` (1–40), `--addressdetails`, `--countrycodes`, `--bounded`, `--viewbox`, `--layer`, `--feature-type`.
+- **Required:**
+  - `--query`
+  - `--format`
+- **Optional:**
+  - `--email`
+  - `--limit` (1–40)
+  - `--addressdetails`
+  - `--countrycodes`
+  - `--bounded`
+  - `--viewbox`
+  - `--layer`
+  - `--feature-type`
 
 ### `search:structured`
 
@@ -58,8 +75,17 @@ simple-nominatim search:free-form --query 'Mountain View, CA, USA' --format 'jso
 simple-nominatim search:structured --country 'USA' --city 'Mountain View' --street '1600 Amphitheatre Parkway' --format 'jsonv2'
 ```
 
-**Required:** `--format` and at least one component (`--amenity`, `--street`, `--city`, `--county`, `--state`, `--country`, `--postal-code`).
-**Optional:** same extras as `search:free-form`.
+- **Required:**
+  - `--format`
+  - At least one component:
+    - `--amenity`
+    - `--street`
+    - `--city`
+    - `--county`
+    - `--state`
+    - `--country`
+    - `--postal-code`
+- **Optional:** same extras as `search:free-form`
 
 > `search:free-form` and `search:structured` **cannot be combined** — use one or the other.
 
@@ -69,7 +95,8 @@ simple-nominatim search:structured --country 'USA' --city 'Mountain View' --stre
 simple-nominatim status:service --format 'json'
 ```
 
-**Optional:** `--format` (`text` | `json`, default `text`).
+- **Optional:**
+  - `--format` (`text` | `json`, default `text`)
 
 ## Exit Codes
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,9 +39,15 @@ const result = await geocodeReverse(
 );
 ```
 
-**Required params:** `latitude`, `longitude` (WGS84).
-**Required options:** `format` (`xml` | `json` | `jsonv2` | `geojson` | `geocodejson`).
-**Common options:** `email`, `zoom` (0–18), `addressdetails`, `layer`.
+- **Required params:**
+  - `latitude`, `longitude` (WGS84)
+- **Required options:**
+  - `format` (`xml` | `json` | `jsonv2` | `geojson` | `geocodejson`)
+- **Common options:**
+  - `email`
+  - `zoom` (0–18)
+  - `addressdetails`
+  - `layer`
 
 ### Search — `freeFormSearch`
 
@@ -54,8 +60,18 @@ const results = await freeFormSearch(
 );
 ```
 
-**Required params:** `query`.
-**Common options:** `email`, `format`, `limit` (1–40), `addressdetails`, `countrycodes`, `bounded`, `viewbox`, `layer`, `featureType`.
+- **Required params:**
+  - `query`
+- **Common options:**
+  - `email`
+  - `format`
+  - `limit` (1–40)
+  - `addressdetails`
+  - `countrycodes`
+  - `bounded`
+  - `viewbox`
+  - `layer`
+  - `featureType`
 
 ### Search — `structuredSearch`
 
@@ -68,8 +84,15 @@ const results = await structuredSearch(
 );
 ```
 
-**Params (all optional, at least one required):** `amenity`, `street`, `city`, `county`, `state`, `country`, `postalCode`.
-**Options:** same as `freeFormSearch`.
+- **Params** (all optional, at least one required):
+  - `amenity`
+  - `street`
+  - `city`
+  - `county`
+  - `state`
+  - `country`
+  - `postalCode`
+- **Options:** same as `freeFormSearch`
 
 ### Status — `serviceStatus`
 
@@ -83,8 +106,8 @@ if (typeof status !== "string" && isStatusSuccess(status)) {
 }
 ```
 
-**Options:** `format` (`text` | `json`, default `text`).
-
+- **Options:**
+  - `format` (`text` | `json`, default `text`)
 - **Text format**: returns the string `"OK"` on success; throws on failure.
 - **JSON format**: returns `StatusSuccessResponse` (`status: 0`) or `StatusErrorResponse` (`status: 700+`).
 


### PR DESCRIPTION
This PR converts inline option and parameter metadata in the `core` and `CLI` package `README` files into bullet lists for better readability.