### PR TITLE
Skip `changeset` status check on release PR

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -24,7 +24,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: pnpm security:audit
         shell: bash
-      - run: pnpm changeset status --since=origin/main
+      - if: github.head_ref != 'changeset-release/main'
+        run: pnpm changeset status --since=origin/main
         shell: bash
       - run: pnpm lint
         shell: bash


### PR DESCRIPTION
This PR prevents the `pnpm changeset status` check from failing on the auto-generated `changeset-release/main` PR, which legitimately removes consumed changeset files as part of the release process.